### PR TITLE
feat(chat-client): 유저 입력 및 로그인/로그아웃 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5",
     "vite-express": "^0.17.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   socket.io:
     specifier: ^4.7.5
     version: 4.7.5
+  socket.io-client:
+    specifier: ^4.7.5
+    version: 4.7.5
   vite-express:
     specifier: ^0.17.0
     version: 0.17.0
@@ -1262,6 +1265,20 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /engine.io-client@6.5.4:
+    resolution: {integrity: sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.5
+      engine.io-parser: 5.2.2
+      ws: 8.17.1
+      xmlhttprequest-ssl: 2.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /engine.io-parser@5.2.2:
     resolution: {integrity: sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==}
     engines: {node: '>=10.0.0'}
@@ -2285,6 +2302,20 @@ packages:
       - utf-8-validate
     dev: false
 
+  /socket.io-client@4.7.5:
+    resolution: {integrity: sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.5
+      engine.io-client: 6.5.4
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
     engines: {node: '>=10.0.0'}
@@ -2509,6 +2540,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
+
+  /xmlhttprequest-ssl@2.0.0:
+    resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
+    engines: {node: '>=0.4.0'}
     dev: false
 
   /yallist@3.1.1:

--- a/server.js
+++ b/server.js
@@ -6,7 +6,13 @@ import ViteExpress from "vite-express";
 const app = express();
 const server = http.createServer(app);
 
-const io = new Server(server);
+const io = new Server(server, {
+    cors: {
+        origin: "*",
+        methods: ["GET", "POST"],
+        credentials: true,
+    },
+});
 
 io.on("connection", (client) => {
     console.log(`클라이언트 ${client.id}가 접속했습니다.`);

--- a/server.js
+++ b/server.js
@@ -15,7 +15,13 @@ const io = new Server(server, {
 });
 
 io.on("connection", (client) => {
-    console.log(`클라이언트 ${client.id}가 접속했습니다.`);
+    const connectedUsername = client.handshake.query.username;
+
+    console.log(`클라이언트 ${connectedUsername}가 접속했습니다.`);
+
+    client.on("disconnect", () => {
+        console.log(`클라이언트 ${connectedUsername}가 접속 종료했습니다.`);
+    })
 });
 server.listen(3000, () => {
     console.log("서버가 포트 3000에서 실행되고 있습니다");
@@ -31,7 +37,7 @@ app.get("/api", (_, res) => {
 });
 
 // 에러 핸들링 미들웨어
-app.use((err, req, res, next) => {
+app.use((err, req, res) => {
     console.error(err.stack);
     res.status(500).send("Something broke!");
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,31 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import { io, Socket } from 'socket.io-client';
+
+type SocketType = Socket | null;
 
 function App() {
   const [count, setCount] = useState(0)
+  const [socket, setSocket] = useState<SocketType>(null);
+  const [username, setUsername] = useState('');
+
+  const connectToChatServer = () => {
+    console.log(connectToChatServer);
+    const _socket = io('http://localhost:3000', {
+      autoConnect: false,
+      query: {
+        username: username,
+      },
+    });
+    _socket.connect();
+    setSocket(_socket);
+  };
+
+  const disconnectToChatServer = () => {
+    socket?.disconnect();
+    setSocket(null);
+  };
 
   return (
     <>
@@ -24,6 +46,18 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+      </div>
+      <h1>유저: {username}</h1>
+      <div className='card'>
+        <input value={username} onChange={e => setUsername(e.target.value)} />
+        {socket ?
+          <button onClick={() => disconnectToChatServer()}>
+            접속 해제하기
+          </button> :
+          <button onClick={() => connectToChatServer()}>
+            접속하기
+          </button>
+        }
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more


### PR DESCRIPTION
## 개요
클라이언트에 사용자 이름 입력 및 서버 연결/해제 기능을 추가하고, 서버에서 로그인/로그아웃 시 사용자 이름을 로깅하며, CORS 이슈를 수정했습니다.

## 변경 사항

### chat-client
- 사용자 이름을 입력받기 위한 input 필드 추가
- 서버에 연결하기 위한 connectToChatServer 함수 추가
- 서버 연결을 해제하기 위한 disconnectToChatServer 함수 추가
- 현재 사용자 이름을 표시하는 h1 요소 추가
- 연결 상태에 따라 버튼 텍스트 변경

### chat-server
- 클라이언트가 접속할 때 핸드셰이크 쿼리에서 사용자 이름을 추출하여 로그로 기록
- 클라이언트가 접속 종료할 때도 해당 사용자 이름을 로그로 기록
- 불필요한 next 매개변수를 제거하여 에러 핸들링 미들웨어를 간소화

### fix(chat-server)
- client가 server에 접속하지 못하는 문제를 해결하기 위해 Socket.io 옵션에 CORS 설정 추가
- 현재는 모든 도메인에서 접속을 허용하도록 설정했지만 추후 신뢰할 수 있는 도메인만 접속이 가능하도록 수정 예정